### PR TITLE
File migration script

### DIFF
--- a/lambdas/layers/util/util/s3.py
+++ b/lambdas/layers/util/util/s3.py
@@ -11,6 +11,7 @@ import util
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+S3_CLIENT = util.get_client('s3')
 
 class S3EventType(Enum):
     """

--- a/scripts/file_update/README.md
+++ b/scripts/file_update/README.md
@@ -1,0 +1,61 @@
+# File Update Script
+
+This script is to be used when there are file data change request. This change could include:
+- Data moved to a different flagship
+- Data moved to a different submission directory
+- AGHA Study ID change for the file
+- Filename change
+
+To execute the script you would need to update the necessary value at 'execute.sh' file. At the top of the script
+there is a 'TODO' section needed for the change.
+- BUCKET_LOCATION - enter the bucket name
+- PARTITION_KEY - partition key for the change (most probably 'TYPE:MANIFEST')
+- SOURCE_SORT_KEY - current s3_key
+- TARGET_SORT_KEY - desired s3_key
+- OVERRIDE_VALUE - this is where you would fill in any changes to manifest file. PLEASE make sure it is in the correct
+json string format. E.g. if you would change agha_study_id, enter '{"agha_study_id":"abcde"}' as the value
+- UPDATE_MANIFEST_TXT - to indicate if you would want to update the manifest.txt file from dynamodb after the change
+
+Additionally, please make sure AWS CLI and AWS_PROFILE is set properly.
+Profile must have the permission to modify `S3` and `DynamoDb`.
+
+After done filling the information, execute the script with:
+```
+./execute.sh
+```
+
+___
+### Explanation of each file
+
+  
+#### script.sh
+This file is the backbone of the script and will run the following order:
+1. Move manifest record file from current s3_key location to desired s3_key location. This includes updated information from the `override_value` arguments.
+2. Move the file of the current to desired s3_key
+3. When `UPDATE_MANIFEST_TXT` is set to `true`. This will update manifest file in both s3_key submission prefix.
+4. This will move `__results.json` and `__log.txt` respectively at the results bucket if necessary.
+
+#### manifest_txt_update.py
+This will update manifest file at the submission prefix from s3_key argument given.
+
+Args:
+- s3_key
+
+
+#### move_manifest_record.py
+This will move the dynamodb manifest record from old to new file. 
+
+Args:
+- bucket_location
+- partition_key
+- old_sort_key
+- new_sort_key 
+- value_override
+
+#### move_and_modify_result_file.py
+This will move `__results.json` and `__log.txt` to the new location.
+The script will modify the content of `__results.json` file to reflect the changes desired and re-upload the file to the desired file.
+
+Args:
+- source_s3_key
+- target_s3_key

--- a/scripts/file_update/execute.sh
+++ b/scripts/file_update/execute.sh
@@ -3,10 +3,10 @@
 ######################################################################################################
 # TODO: Fill this this section for the migration
 # TODO: Please also export your AWS credentials to AWS_PROFILE
-export BUCKET_LOCATION="agha-staging-dev"
+export BUCKET_LOCATION="agha-gdr-store-2.0"
 export PARTITION_KEY="TYPE:MANIFEST"
-export SOURCE_SORT_KEY="ACG/20210722_090101/SBJ00592-somatic-PASS.vcf.gz"
-export TARGET_SORT_KEY="AZ/1234567890/SBJ00592-somatic-PASS.vcf.gz"
+export TARGET_SORT_KEY="ABC/0123456789/SOME-FILE.vcf.gz"
+export SOURCE_SORT_KEY="XYZ/987654321/SOME-FILE.vcf.gz"
 export OVERRIDE_VALUE='{"agha_study_id":"abcde"}'  # Make sure it is a JSON string object
 
 # Update manifest.txt file in submission level by toggling 'UPDATE_MANIFEST_TXT' variable
@@ -24,9 +24,9 @@ export DYNAMODB_ETAG_TABLE_NAME='agha-gdr-e-tag'
 export DYNAMODB_RESULT_TABLE_NAME='agha-gdr-result-bucket'
 export DYNAMODB_STAGING_TABLE_NAME='agha-gdr-staging-bucket'
 export DYNAMODB_STORE_TABLE_NAME='agha-gdr-store-bucket'
-export STAGING_BUCKET='agha-staging-dev'
-export RESULT_BUCKET='agha-results-dev'
-export STORE_BUCKET='agha-store-dev'
+export STAGING_BUCKET='agha-gdr-staging-2.0'
+export RESULT_BUCKET='agha-gdr-results-2.0'
+export STORE_BUCKET='agha-gdr-store-2.0'
 
 ######################################################################################################
 

--- a/scripts/file_update/execute.sh
+++ b/scripts/file_update/execute.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+######################################################################################################
+# TODO: Fill this this section for the migration
+# TODO: Please also export your AWS credentials to AWS_PROFILE
+export BUCKET_LOCATION="agha-staging-dev"
+export PARTITION_KEY="TYPE:MANIFEST"
+export SOURCE_SORT_KEY="ACG/20210722_090101/SBJ00592-somatic-PASS.vcf.gz"
+export TARGET_SORT_KEY="AZ/1234567890/SBJ00592-somatic-PASS.vcf.gz"
+export OVERRIDE_VALUE='{"agha_study_id":"abcde"}'  # Make sure it is a JSON string object
+
+# Update manifest.txt file in submission level by toggling 'UPDATE_MANIFEST_TXT' variable
+# Ideally you would only trigger this for the last move file in the submission
+
+export UPDATE_MANIFEST_TXT=true  # Boolean value (lower case): true, false
+
+######################################################################################################
+
+# Setting environment variables
+export DYNAMODB_ARCHIVE_RESULT_TABLE_NAME='agha-gdr-result-bucket-archive'
+export DYNAMODB_ARCHIVE_STAGING_TABLE_NAME='agha-gdr-staging-bucket-archive'
+export DYNAMODB_ARCHIVE_STORE_TABLE_NAME='agha-gdr-store-bucket-archive'
+export DYNAMODB_ETAG_TABLE_NAME='agha-gdr-e-tag'
+export DYNAMODB_RESULT_TABLE_NAME='agha-gdr-result-bucket'
+export DYNAMODB_STAGING_TABLE_NAME='agha-gdr-staging-bucket'
+export DYNAMODB_STORE_TABLE_NAME='agha-gdr-store-bucket'
+export STAGING_BUCKET='agha-staging-dev'
+export RESULT_BUCKET='agha-results-dev'
+export STORE_BUCKET='agha-store-dev'
+
+######################################################################################################
+
+# AWS CLI existence check
+command -v aws >/dev/null 2>&1 || {
+  echo >&2 "AWS CLI COMMAND NOT FOUND. ABORTING..."
+  exit 1
+}
+
+# AWS Creds check
+aws sts get-caller-identity >/dev/null 2>&1 || {
+  echo >&2 "UNABLE TO LOCATE CREDENTIALS. YOUR AWS LOGIN SESSION HAVE EXPIRED. PLEASE LOGIN. ABORTING..."
+  exit 1
+}
+
+# Move dynamodb manifest
+python move_manifest_record.py \
+  --bucket_location ${BUCKET_LOCATION} \
+  --partition_key ${PARTITION_KEY} \
+  --old_sort_key ${SOURCE_SORT_KEY} \
+  --new_sort_key ${TARGET_SORT_KEY} \
+  --value_override ${OVERRIDE_VALUE} \
+  2>&1 || {
+    echo >&2 "FAIL DYNAMODB UPDATE. ABORTING..."
+    exit 1
+}
+
+# Move the file object
+echo "Moving original file"
+s3_uri_source="s3://${BUCKET_LOCATION}/${SOURCE_SORT_KEY}"
+s3_uri_target="s3://${BUCKET_LOCATION}/${TARGET_SORT_KEY}"
+aws s3 mv "${s3_uri_source}" "${s3_uri_target}"
+
+ Update manifest.txt file for each submission
+if [ "$UPDATE_MANIFEST_TXT" == true ] && [ "$BUCKET_LOCATION" == $STORE_BUCKET ]; then
+  echo "Updating manifest.txt file (in source and target submission)"
+  python manifest_txt_update.py --s3_key_object $SOURCE_SORT_KEY
+  python manifest_txt_update.py --s3_key_object $TARGET_SORT_KEY
+
+fi
+
+# Move '__results.json' location
+echo "Moving results json file with modification"
+python move_and_modify_results_file.py \
+  --source_s3_key "${SOURCE_SORT_KEY}" \
+  --target_s3_key "${TARGET_SORT_KEY}" \
+  2>&1 || {
+    echo >&2 "No results file found. Terminating ... "
+    exit 1
+}
+
+echo "Script Execute Successfully"
+
+

--- a/scripts/file_update/manifest_txt_update.py
+++ b/scripts/file_update/manifest_txt_update.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import sys
+import logging
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+from util import dynamodb, s3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Setting some variables
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--s3_key_object', required=True, type=str,
+                        help='s3 key')
+    return parser.parse_args()
+
+
+def update_manifest_file(args):
+    # Strip filename to get submission prefix
+    submission_prefix = os.path.dirname(args.s3_key_object) + '/'
+
+    # Create new manifest file from dynamodb given
+    manifest_item = dynamodb.get_batch_item_from_pk_and_sk(DYNAMODB_STORE_TABLE_NAME,
+                                                           dynamodb.FileRecordPartitionKey.MANIFEST_FILE_RECORD.value,
+                                                           submission_prefix)
+    # Define manifest file
+    new_manifest_file = 'checksum\tfilename\tagha_study_id\n'  # First line is header
+
+    # Iterate to manifest list
+    for item in manifest_item:
+        checksum = item['provided_checksum']
+        filename = item['filename']
+        agha_study_id = item['agha_study_id']
+
+        new_manifest_file += f'{checksum}\t{filename}\t{agha_study_id}\n'
+    manifest_destination_key = submission_prefix + 'manifest.txt'
+    s3.upload_s3_object_from_string(bucket_name=STORE_BUCKET,
+                                    byte_of_string=new_manifest_file,
+                                    s3_key_destination=manifest_destination_key)
+
+    logger.info(f'Uploaded dynamodb manifest.txt')
+
+
+if __name__ == '__main__':
+    args = get_arguments()
+    update_manifest_file(args)

--- a/scripts/file_update/move_and_modify_results_file.py
+++ b/scripts/file_update/move_and_modify_results_file.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import sys
+import json
+import logging
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+import util
+from util import agha, s3, dynamodb
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Setting some variables
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--source_s3_key', required=True, type=str,
+                        help='Source results s3 key')
+    parser.add_argument('--target_s3_key', required=True, type=str,
+                        help='Target results s3 key')
+    return parser.parse_args()
+
+
+def mode_and_modify_result(args):
+
+    results_source_s3_key = args.source_s3_key + '__results.json'
+    results_target_s3_key = args.target_s3_key + '__results.json'
+
+    # Convert filename to submitted naming (convert to uncompress if submitted uncompress)
+    if agha.FileType.is_compress_file(args.source_s3_key):
+        # Find for non-compress file if it was used at the result stage
+        dydb_res = dynamodb.get_item_from_exact_pk_and_sk(
+            table_name=DYNAMODB_RESULT_TABLE_NAME,
+            partition_key=dynamodb.FileRecordPartitionKey.FILE_RECORD.value,
+            sort_key=f"{args.source_s3_key.strip('.gz')}__results.json"
+        )
+        if dydb_res['Count'] == 1:
+
+            results_source_s3_key = f"{args.source_s3_key.strip('.gz')}__results.json"
+            results_target_s3_key = f"{args.target_s3_key.strip('.gz')}__results.json"
+
+    # Try to grab results list file
+    try:
+        results_list = s3.get_object_from_bucket_name_and_s3_key(bucket_name=RESULT_BUCKET,
+                                                                 s3_key=results_source_s3_key)
+
+    except s3.S3_CLIENT.exceptions.NoSuchKey as e:
+        print(f"File not found error: {e}")
+        print("Possible data has not gone through the validation or no data generated for this s3_key.")
+        print("Exiting here ... ")
+        sys.exit(1)
+
+    # Modify content of the array
+    new_s3_key = results_target_s3_key.strip('__results.json')
+    for result_data in results_list:
+        result_data['staging_s3_key'] = new_s3_key
+
+    print(f'New results.json file: {json.dumps(results_list, indent=4, cls=util.JsonSerialEncoder)}')
+
+    # Upload back to s3
+    s3.upload_s3_object_from_string(bucket_name=RESULT_BUCKET,
+                                    byte_of_string=json.dumps(results_list, indent=4, cls=util.JsonSerialEncoder),
+                                    s3_key_destination=results_target_s3_key)
+    # Delete old results files
+    s3.delete_s3_object_from_key(bucket_name=RESULT_BUCKET,
+                                 key_list=[results_source_s3_key])
+    print('Modification completed')
+
+    ######################################################################################################
+    # Moving log files
+
+    s3_uri_source=f"s3://{RESULT_BUCKET}/{args.source_s3_key}__log.txt"
+    s3_uri_target=f"s3://{RESULT_BUCKET}/{args.target_s3_key}__log.txt"
+    os.system(f"aws s3 mv {s3_uri_source} {s3_uri_target}")
+
+
+if __name__ == '__main__':
+    arg = get_arguments()
+    mode_and_modify_result(arg)

--- a/scripts/file_update/move_manifest_record.py
+++ b/scripts/file_update/move_manifest_record.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import sys
+import json
+import logging
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+import util
+from util import dynamodb, s3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Setting some variables
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bucket_location', required=True, type=str, choices=[STAGING_BUCKET, STORE_BUCKET],
+                        help='The bucket location of the file')
+    parser.add_argument('--partition_key', required=True, type=str,
+                        help='The partition key for the file')
+    parser.add_argument('--old_sort_key', required=True, type=str,
+                        help='Source sort key')
+    parser.add_argument('--new_sort_key', required=True, type=str,
+                        help='Target source key')
+    parser.add_argument('--value_override', required=False, type=str,
+                        help='Json String to override value')
+    return parser.parse_args()
+
+
+def move_and_update_manifest_record(event_payload):
+    if event_payload.bucket_location == STORE_BUCKET:
+        table_name = DYNAMODB_STORE_TABLE_NAME
+        archive_table_name = DYNAMODB_ARCHIVE_STORE_TABLE_NAME
+    else:
+        table_name = DYNAMODB_STAGING_TABLE_NAME
+        archive_table_name = DYNAMODB_ARCHIVE_STAGING_TABLE_NAME
+
+    ################################################################################
+    # Grab Manifest existing DyDb from
+    logger.info('Fetching dynamodb record')
+    dynamodb_res = dynamodb.get_item_from_exact_pk_and_sk(
+        table_name=table_name,
+        partition_key=event_payload.partition_key,
+        sort_key=event_payload.old_sort_key,
+    )
+
+    dynamodb_item = dynamodb_res['Items'][0]
+
+    ################################################################################
+    # Manipulate any change value
+
+    logger.info('Change dynamodb manifest record')
+    # Change from json string payload (e.g. change flagship, agha_study_id )
+    override_values = event_payload.value_override
+    if override_values is not None:
+        json_val = json.loads(override_values)
+        for key in json_val:
+            val = json_val[key]
+
+            # Change to override values
+            dynamodb_item[key] = val
+
+    # Change to newly sort_key
+    new_sort_key = event_payload.new_sort_key
+    dynamodb_item['sort_key'] = new_sort_key
+
+    # Change to new flagship
+    new_flagship_code = new_sort_key.split('/')[0]
+    dynamodb_item['flagship'] = new_flagship_code
+
+    # Change date modified
+    dynamodb_item['date_modified'] = util.get_datetimestamp()
+
+    print(f'New dynamodb record: {json.dumps(dynamodb_item, indent=4)}')
+    ################################################################################
+    # Update DyDb
+
+    logger.info("Adding new file to dydb")
+    # Upload new dydb record
+    dynamodb.batch_write_objects(
+        table_name=table_name,
+        object_list=[dynamodb_item]
+    )
+
+    dynamodb.batch_write_objects_archive(table_name=archive_table_name,
+                                         object_list=[dynamodb_item],
+                                         archive_log=s3.S3EventType.EVENT_OBJECT_CREATED.value)
+
+    # Double-checking
+    dynamodb_res = dynamodb.get_item_from_exact_pk_and_sk(
+        table_name=table_name,
+        partition_key=event_payload.partition_key,
+        sort_key=event_payload.new_sort_key,
+    )
+    if dynamodb_res['Count'] == 1:
+        logger.info('Success update new manifest')
+    else:
+        logger.error('Something wrong on updating new manifest data')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    event_payload = get_arguments()
+    move_and_update_manifest_record(event_payload)


### PR DESCRIPTION
Folder containing scripts for changing study_id and/or location of the file.

These changes could include:
- Data moved to a different flagship
- Data moved to a different submission directory
- AGHA Study ID change for the file
- Filename change

The script divided to multiple python file and bash file as an orchestrator.
These arrangement could hopefully be useful in the future if this script will become online and take each python file as lambda and bash script as step function.

The script will do the following steps:
1. Move manifest record file from current to desired s3_key. This includes updated information from the `override_value` arguments.
2. Move the file of the current to desired s3_key
3. When `UPDATE_MANIFEST_TXT` is set to `true`. This will update manifest file in both s3_key submission prefix.
4. Then will move `__results.json` and `__log.txt` respectively at the results bucket if necessary.

Upon approval, then I'll run this script for `BM/2019-07-22` change request.

