### PR TITLE
Implement multi study

### DIFF
--- a/lambdas/functions/manifest_processor/manifest_processor.py
+++ b/lambdas/functions/manifest_processor/manifest_processor.py
@@ -204,7 +204,7 @@ def handler(event, context):
                 notification.log_and_store_message(f"No such file found at bucket:{DYNAMODB_STAGING_TABLE_NAME}\
                  s3_key:{sort_key}", 'warning')
                 notification.notify_and_exit()
-            logger.info(f'File check in s3 bucket: OK.')
+            logger.debug(f'File check \'{sort_key}\' in s3 bucket: OK.')
 
             file_etag = query_submission_df['etag'].values[0]
 
@@ -278,7 +278,7 @@ def handler(event, context):
                 manifest_status_record.additional_information = [report_info]
 
             notification.log_and_store_message(
-                'Trigger of validation pipeline has been disabled due to UNRECOGNIZED/UNRECOGNIZED filetype found.',
+                'Trigger of validation pipeline has been disabled due to UNRECOGNIZED filetype found.',
                 'critical')
             notification.log_and_store_message(f'Please check/resubmit submitted file.', 'critical')
             notification.log_and_store_message(
@@ -288,8 +288,7 @@ def handler(event, context):
             # List all duplicates file
             notification.log_and_store_message(
                 "The following list are files of unrecognized file.<br>")
-            list_of_duplicate_files_email_format = json.dumps(data.files_extra, indent=4, sort_keys=True).replace(
-                ' ', '&nbsp;').replace('\n', '<br>')
+            list_of_duplicate_files_email_format = json.dumps(data.files_extra, indent=4, sort_keys=True)
             notification.log_and_store_message(list_of_duplicate_files_email_format)
 
             # Skip the auto validation
@@ -321,8 +320,7 @@ def handler(event, context):
             # List all duplicates file
             notification.log_and_store_message(
                 "The following list are files with the same eTag at multiple location.<br>")
-            list_of_duplicate_files_email_format = json.dumps(duplicate_etag_list, indent=4, sort_keys=True).replace(
-                ' ', '&nbsp;').replace('\n', '<br>')
+            list_of_duplicate_files_email_format = json.dumps(duplicate_etag_list, indent=4, sort_keys=True)
             notification.log_and_store_message(list_of_duplicate_files_email_format)
 
             # Skip the auto validation

--- a/lambdas/layers/util/util/notification.py
+++ b/lambdas/layers/util/util/notification.py
@@ -81,7 +81,9 @@ def log_and_store_message(message, level='info'):
     elif level == 'warning':
         message = f'WARNING: {message}'
 
-    MESSAGE_STORE.append(message)
+    email_message_format = message.replace(' ', '&nbsp;').replace('\n', '<br>')
+
+    MESSAGE_STORE.append(email_message_format)
 
 def log_and_store_list_message(list_messages, level='info'):
 

--- a/lambdas/layers/util/util/submission_data.py
+++ b/lambdas/layers/util/util/submission_data.py
@@ -189,9 +189,11 @@ def validate_manifest(data: SubmissionData, postfix_exception_list: list, skip_c
             continue
 
         # Study ID
-        if not AGHA_ID_RE.match(row.agha_study_id):
-            message = f'Malformed AGHA study ID: {row.filename} ({row.agha_study_id})'
-            messages_error.append(message)
+        agha_study_id_list = row.agha_study_id.split(',')  # Separate by commas for multi study-id
+        for agha_study_id in agha_study_id_list:
+            if not AGHA_ID_RE.match(agha_study_id):
+                message = f'Malformed AGHA study ID: {row.filename} ({agha_study_id})'
+                messages_error.append(message)
         # Checksum
         if not MD5_RE.match(row.checksum) and not skip_checksum_check:
             message = f'Malformed MD5 checksum: {row.filename} ({row.checksum})'


### PR DESCRIPTION
Manifest file could now contain multiple `agha_study_id` for 1 file in the `manifest.txt`, by separating the values with comma.
e.g. 
```
A19000,A19001
```

