### PR TITLE
add remove duplicate file script

### DIFF
--- a/scripts/handle_duplicates/README.md
+++ b/scripts/handle_duplicates/README.md
@@ -1,0 +1,17 @@
+# Handle duplicate script
+
+The main goal is to remove any duplicate within flagship
+
+To execute the script you would need to update the necessary value at 'execute.sh' file. At the top of the script
+there is a 'TODO' section needed for the change.
+- BUCKET_LOCATION - enter the bucket name
+- FLAGSHIP - Flagship Code in the s3 bucket
+- UPDATE_MANIFEST_TXT - to indicate if you would want to update the manifest.txt file from dynamodb after the change
+
+Additionally, please make sure AWS CLI and AWS_PROFILE is set properly.
+Profile must have the permission to modify `S3` and `DynamoDb`.
+
+After done filling the information, execute the script with:
+```
+./execute.sh
+```

--- a/scripts/handle_duplicates/execute.sh
+++ b/scripts/handle_duplicates/execute.sh
@@ -4,7 +4,7 @@
 # TODO: Fill this this section for the migration
 # TODO: Please also export your AWS credentials to AWS_PROFILE
 export BUCKET_NAME="agha-gdr-store-2.0"
-export FLAGSHIP="EE"
+export FLAGSHIP="SOMEFLAGSHIP"
 
 # Update manifest.txt file in submission level by toggling 'UPDATE_MANIFEST_TXT' variable
 # Ideally you would only trigger this for the last move file in the submission

--- a/scripts/handle_duplicates/execute.sh
+++ b/scripts/handle_duplicates/execute.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+######################################################################################################
+# TODO: Fill this this section for the migration
+# TODO: Please also export your AWS credentials to AWS_PROFILE
+export BUCKET_NAME="agha-gdr-store-2.0"
+export FLAGSHIP="EE"
+
+# Update manifest.txt file in submission level by toggling 'UPDATE_MANIFEST_TXT' variable
+# Ideally you would only trigger this for the last move file in the submission
+
+export UPDATE_MANIFEST_TXT=true  # Boolean value (lower case): true, false
+
+######################################################################################################
+
+# Setting environment variables
+export DYNAMODB_ARCHIVE_RESULT_TABLE_NAME='agha-gdr-result-bucket-archive'
+export DYNAMODB_ARCHIVE_STAGING_TABLE_NAME='agha-gdr-staging-bucket-archive'
+export DYNAMODB_ARCHIVE_STORE_TABLE_NAME='agha-gdr-store-bucket-archive'
+export DYNAMODB_ETAG_TABLE_NAME='agha-gdr-e-tag'
+export DYNAMODB_RESULT_TABLE_NAME='agha-gdr-result-bucket'
+export DYNAMODB_STAGING_TABLE_NAME='agha-gdr-staging-bucket'
+export DYNAMODB_STORE_TABLE_NAME='agha-gdr-store-bucket'
+export STAGING_BUCKET='agha-gdr-staging-2.0'
+export RESULT_BUCKET='agha-gdr-results-2.0'
+export STORE_BUCKET='agha-gdr-store-2.0'
+
+######################################################################################################
+
+# AWS CLI existence check
+command -v aws >/dev/null 2>&1 || {
+  echo >&2 "AWS CLI COMMAND NOT FOUND. ABORTING..."
+  exit 1
+}
+
+# AWS Creds check
+aws sts get-caller-identity >/dev/null 2>&1 || {
+  echo >&2 "UNABLE TO LOCATE CREDENTIALS. YOUR AWS LOGIN SESSION HAVE EXPIRED. PLEASE LOGIN. ABORTING..."
+  exit 1
+}
+
+# Move dynamodb manifest
+python find_and_delete_duplicates.py --bucket_name ${BUCKET_NAME} --flagship ${FLAGSHIP}
+
+echo "Script Execute Successfully"
+
+

--- a/scripts/handle_duplicates/find_and_delete_duplicates.py
+++ b/scripts/handle_duplicates/find_and_delete_duplicates.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import sys
+import json
+import logging
+import time
+
+import pandas as pd
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+import util
+from util import agha, s3, dynamodb
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Setting some variables
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bucket_name', required=True, type=str, choices=[STAGING_BUCKET, STORE_BUCKET],
+                        help='The bucket name to search (either the staging/store name)')
+    parser.add_argument('--flagship', required=True, type=str, choices=agha.FlagShip.list_flagship_enum(),
+                        help='Directory prefix for the submission. Example: EE')
+    return parser.parse_args()
+
+
+def count_1(a):
+    return str(a) + "bebe"
+
+
+def find_and_duplicates(bucket_name, flagship):
+    ################################################################################
+    # Finding what to delete
+
+    if not flagship.endswith('/'):
+        flagship += '/'
+
+    list_of_metadata = s3.get_s3_object_metadata(
+        bucket_name=bucket_name,
+        directory_prefix=flagship
+    )
+
+    metadata_df = pd.json_normalize(list_of_metadata)
+
+    etag_df = metadata_df['ETag']
+    duplicates_record = metadata_df[etag_df.isin(etag_df[etag_df.duplicated()])].sort_values(by='Key')
+    print(f"Number of duplication: {len(duplicates_record)}")
+
+    # Alternative:
+    # etag_count_df = metadata_df.ETag.value_counts()
+    # duplicates_record = metadata_df[metadata_df.ETag.isin(etag_count_df.index[etag_count_df.gt(1)])]
+
+    # Group Etag so only 1 file are kept based on the first submission appear (sorted by Key)
+    records_to_keep = duplicates_record.sort_values(by='Key').groupby('ETag', as_index=False).first()
+    print(f"Number of records to keep: {len(records_to_keep)}")
+
+    # Find the deletion list (difference between duplicated_df and records_to_keep_df)
+    to_delete_df = pd.concat([duplicates_record, records_to_keep]).drop_duplicates(keep=False)
+    print(f"Number of records to delete{len(to_delete_df)}")
+
+    ################################################################################
+    # Deleting ...
+
+    deletion_s3_list = to_delete_df['Key'].tolist()
+    print(f" File to delete from s3 store: {json.dumps(deletion_s3_list, indent=4)}")
+
+    # s3.delete_s3_object_from_key(bucket_name=bucket_name, key_list=deletion_s3_list)
+
+    ################################################################################
+    # Link associated file after post process after deletion
+
+    time.sleep(5)  # Just some buffer time to let lambda s3_event listener to finish execute
+
+    submission_prefix_list = list(set([('/'.join(key.split('/')[:-1]) + '/') for key in deletion_s3_list]))
+
+    for submission in submission_prefix_list:
+
+        if bucket_name == STORE_BUCKET:
+            # Update manifests.txt via 'manifest_txt_update.py' file
+            os.system(f"python ../util/manifest_txt_update.py --s3_key_object {submission}")
+
+        # Update results bucket content via sync python file
+        os.system(f"python ../util/sync_results_bucket.py --sync_from {STORE_BUCKET} --sort_key_prefix {submission}")
+
+
+if __name__ == '__main__':
+
+    args = get_arguments()
+
+    find_and_duplicates(args.bucket_name, args.flagship)

--- a/scripts/handle_duplicates/find_and_delete_duplicates.py
+++ b/scripts/handle_duplicates/find_and_delete_duplicates.py
@@ -36,18 +36,16 @@ DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
 DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
 DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
 
+FLAGSHIP_LIST_CHOICE = list(set(agha.FlagShip.list_flagship_enum()) - {'TEST', 'UNKNOWN'})
+
 
 def get_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('--bucket_name', required=True, type=str, choices=[STAGING_BUCKET, STORE_BUCKET],
                         help='The bucket name to search (either the staging/store name)')
-    parser.add_argument('--flagship', required=True, type=str, choices=agha.FlagShip.list_flagship_enum(),
+    parser.add_argument('--flagship', required=True, type=str, choices=FLAGSHIP_LIST_CHOICE,
                         help='Directory prefix for the submission. Example: EE')
     return parser.parse_args()
-
-
-def count_1(a):
-    return str(a) + "bebe"
 
 
 def find_and_duplicates(bucket_name, flagship):
@@ -86,7 +84,7 @@ def find_and_duplicates(bucket_name, flagship):
     deletion_s3_list = to_delete_df['Key'].tolist()
     print(f" File to delete from s3 store: {json.dumps(deletion_s3_list, indent=4)}")
 
-    # s3.delete_s3_object_from_key(bucket_name=bucket_name, key_list=deletion_s3_list)
+    s3.delete_s3_object_from_key(bucket_name=bucket_name, key_list=deletion_s3_list)
 
     ################################################################################
     # Link associated file after post process after deletion
@@ -106,7 +104,6 @@ def find_and_duplicates(bucket_name, flagship):
 
 
 if __name__ == '__main__':
-
     args = get_arguments()
 
     find_and_duplicates(args.bucket_name, args.flagship)

--- a/scripts/handle_duplicates/find_and_delete_duplicates.py
+++ b/scripts/handle_duplicates/find_and_delete_duplicates.py
@@ -82,7 +82,8 @@ def find_and_duplicates(bucket_name, flagship):
     # Deleting ...
 
     deletion_s3_list = to_delete_df['Key'].tolist()
-    print(f" File to delete from s3 store: {json.dumps(deletion_s3_list, indent=4)}")
+    print(f"Number of Index files deleted: {len([key for key in deletion_s3_list if agha.FileType.is_index_file(key)])}")
+    print(f"File to delete from s3 store: {json.dumps(deletion_s3_list, indent=4)}")
 
     s3.delete_s3_object_from_key(bucket_name=bucket_name, key_list=deletion_s3_list)
 
@@ -92,6 +93,7 @@ def find_and_duplicates(bucket_name, flagship):
     time.sleep(5)  # Just some buffer time to let lambda s3_event listener to finish execute
 
     submission_prefix_list = list(set([('/'.join(key.split('/')[:-1]) + '/') for key in deletion_s3_list]))
+    submission_prefix_list.sort()
 
     for submission in submission_prefix_list:
 

--- a/scripts/handle_duplicates/find_and_delete_duplicates.py
+++ b/scripts/handle_duplicates/find_and_delete_duplicates.py
@@ -76,7 +76,7 @@ def find_and_duplicates(bucket_name, flagship):
 
     # Find the deletion list (difference between duplicated_df and records_to_keep_df)
     to_delete_df = pd.concat([duplicates_record, records_to_keep]).drop_duplicates(keep=False)
-    print(f"Number of records to delete{len(to_delete_df)}")
+    print(f"Number of records to delete: {len(to_delete_df)}")
 
     ################################################################################
     # Deleting ...

--- a/scripts/util/manifest_txt_update.py
+++ b/scripts/util/manifest_txt_update.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import sys
+import logging
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+from util import dynamodb, s3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Setting some variables
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--s3_key_object', required=True, type=str,
+                        help='s3 key')
+    return parser.parse_args()
+
+
+def update_manifest_file(args):
+    # Strip filename to get submission prefix
+    submission_prefix = os.path.dirname(args.s3_key_object) + '/'
+
+    # Create new manifest file from dynamodb given
+    manifest_item = dynamodb.get_batch_item_from_pk_and_sk(DYNAMODB_STORE_TABLE_NAME,
+                                                           dynamodb.FileRecordPartitionKey.MANIFEST_FILE_RECORD.value,
+                                                           submission_prefix)
+    # Define manifest file
+    new_manifest_file = 'checksum\tfilename\tagha_study_id\n'  # First line is header
+
+    # Iterate to manifest list
+    for item in manifest_item:
+        checksum = item['provided_checksum']
+        filename = item['filename']
+        agha_study_id = item['agha_study_id']
+
+        new_manifest_file += f'{checksum}\t{filename}\t{agha_study_id}\n'
+    manifest_destination_key = submission_prefix + 'manifest.txt'
+    s3.upload_s3_object_from_string(bucket_name=STORE_BUCKET,
+                                    byte_of_string=new_manifest_file,
+                                    s3_key_destination=manifest_destination_key)
+
+    logger.info(f'Uploaded dynamodb manifest.txt')
+
+
+if __name__ == '__main__':
+    args = get_arguments()
+    update_manifest_file(args)

--- a/scripts/util/sync_results_bucket.py
+++ b/scripts/util/sync_results_bucket.py
@@ -1,38 +1,59 @@
 import sys
+import os
 import logging
-import util.s3 as s3
-import util.dynamodb as dy
-import util.dynamodb as dynamodb
-import util.agha as agha
-import util as util
-import util.batch as batch
+import argparse
 import json
 import time
-from boto3.dynamodb.conditions import Attr
-
 import botocore
 
-STORE_BUCKET_NAME = 'agha-gdr-store-2.0'
-STAGING_BUCKET_NAME = 'agha-gdr-staging-2.0'
-RESULTS_BUCKET_NAME = 'agha-gdr-results-2.0'
+from boto3.dynamodb.conditions import Attr
 
-DYNAMODB_STAGING_TABLE = "agha-gdr-staging-bucket"
-DYNAMODB_STORE_TABLE = "agha-gdr-store-bucket"
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+SOURCE_PATH = os.path.join(
+    DIR_PATH, "..", "..", "lambdas", "layers", "util"
+)
+sys.path.append(SOURCE_PATH)
+
+from util import s3, dynamodb, agha, batch
+
+# Buckets
+STAGING_BUCKET = os.environ.get('STAGING_BUCKET')
+STORE_BUCKET = os.environ.get('STORE_BUCKET')
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET')
+
+# Dynamodb
+DYNAMODB_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_STAGING_TABLE_NAME')
+DYNAMODB_ARCHIVE_STAGING_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STAGING_TABLE_NAME')
+DYNAMODB_STORE_TABLE_NAME = os.environ.get('DYNAMODB_STORE_TABLE_NAME')
+DYNAMODB_ARCHIVE_STORE_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_STORE_TABLE_NAME')
+DYNAMODB_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_RESULT_TABLE_NAME')
+DYNAMODB_ARCHIVE_RESULT_TABLE_NAME = os.environ.get('DYNAMODB_ARCHIVE_RESULT_TABLE_NAME')
+DYNAMODB_ETAG_TABLE_NAME = os.environ.get('DYNAMODB_ETAG_TABLE_NAME')
 
 
-def sync_result_bucket():
+def get_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--sync_from', required=True, type=str,
+                        help='Which bucket to sync to (staging/store bucket or staging/store manifest dynamodb table)')
+    parser.add_argument('--sort_key_prefix', required=True, type=str,
+                        help=' submission prefix')
+    return parser.parse_args()
+
+
+
+def sync_result_bucket(args):
 
     # TODO: Which bucket to sync to (staging/store bucket or staging/store manifest dynamodb table)
-    sync_from = 'UNKNOWN'
+    sync_from = args.sync_from
     # TODO: Change the submission prefix
-    sort_key_prefix = "HIDDEN/2021-10-26/"
+    sort_key_prefix = args.sort_key_prefix
 
     # Grab filename from main bucket
-    if sync_from == STAGING_BUCKET_NAME or sync_from == STORE_BUCKET_NAME:
+    if sync_from == STAGING_BUCKET or sync_from == STORE_BUCKET:
         metadata_list_main_bucket = s3.get_s3_object_metadata(bucket_name=sync_from, directory_prefix=sort_key_prefix)
         filename_main_bucket = [metadata['Key'].split('/')[-1] for metadata in metadata_list_main_bucket]
 
-    elif sync_from == DYNAMODB_STAGING_TABLE or sync_from == DYNAMODB_STORE_TABLE:
+    elif sync_from == DYNAMODB_STAGING_TABLE_NAME or sync_from == DYNAMODB_STORE_TABLE_NAME:
         item_res = dynamodb.get_batch_item_from_pk_and_sk(table_name=sync_from,
                                                           partition_key=dynamodb.FileRecordPartitionKey.MANIFEST_FILE_RECORD.value,
                                                           sort_key_prefix=sort_key_prefix)
@@ -42,7 +63,7 @@ def sync_result_bucket():
         return
 
     # Grab results file data
-    metadata_list_results_bucket = s3.get_s3_object_metadata(bucket_name=RESULTS_BUCKET_NAME,
+    metadata_list_results_bucket = s3.get_s3_object_metadata(bucket_name=RESULT_BUCKET,
                                                              directory_prefix=sort_key_prefix)
     s3key_results_bucket = [metadata['Key'] for metadata in metadata_list_results_bucket]
 
@@ -70,13 +91,14 @@ def sync_result_bucket():
             list_for_deletion.append(s3_key)
 
     # Print result for deletion list before executing it
-    print('List for deletion:', json.dumps(list_for_deletion, indent=4))
-    return
+    print(' File to delete from s3 results:', json.dumps(list_for_deletion, indent=4))
 
-    res = s3.delete_s3_object_from_key(RESULTS_BUCKET_NAME, list_for_deletion)
-
+    res = s3.delete_s3_object_from_key(RESULT_BUCKET, list_for_deletion)
     print(res)
 
 
 if __name__ == '__main__':
-    sync_result_bucket()
+
+    args = get_arguments()
+
+    sync_result_bucket(args)


### PR DESCRIPTION
Added Script for detecting `ETag` duplication within flagships and deleting it accordingly.

The step of deletion:
1. From the flagship list all object in the FlagShip submission
2. Search for any same `ETag` value, and list the files that are in the newer submission to be deleted.
3. Delete the files and update the `manifest.txt` in the store bucket to reflect changes.
4. Sync the result bucket with staging/store bucket to reflect what is being deleted (in staging/store bucket)