### PR TITLE
Update Report and CleanUp lambda

### DIFF
--- a/lambdas/functions/cleanup_manager/tests/__init__.py
+++ b/lambdas/functions/cleanup_manager/tests/__init__.py
@@ -9,5 +9,5 @@ sys.path.append(SOURCE_PATH)
 
 
 # Setting up environment variable
-os.environ["FOLDER_LOCK_LAMBDA_ARN"] = 'arn:aws:lambda:ap-southeast-2:602836945884:function:agha-gdr-validation-pipeline-folder-lock'
 os.environ["STAGING_BUCKET"] = 'agha-gdr-staging-2.0'
+os.environ["STORE_BUCKET"] = 'agha-gdr-store-2.0'

--- a/lambdas/functions/cleanup_manager/tests/test_cleanup_manager.py
+++ b/lambdas/functions/cleanup_manager/tests/test_cleanup_manager.py
@@ -18,7 +18,7 @@ from cleanup_manager import handler
 
 def create_cleanup_manager_payload():
     return {
-        "submission_directory": "BM/2021-01-16/"
+        "submission_directory": "ICCon/2022-03-21/"
     }
 
 

--- a/stacks/agha_stacks/lambda_stack.py
+++ b/stacks/agha_stacks/lambda_stack.py
@@ -93,6 +93,7 @@ class LambdaStack(core.NestedStack):
             code=lambda_.Code.from_asset('lambdas/functions/cleanup_manager'),
             environment={
                 # Buckets
+                'STORE_BUCKET': bucket_name['store_bucket'],
                 'STAGING_BUCKET': bucket_name['staging_bucket']
             },
             role=cleanup_manager_lambda_role,


### PR DESCRIPTION
Ignore error if directory exist in store bucket but not in staging bucket. The following affected lambda:
- At cleanup lambda, allow to generate Readme.txt for the submission in staging
- At report lambda, return OK status if not data exist in staging but exist in store