### PR TITLE
Update Python Manual Scripts

### DIFF
--- a/scripts/file_update/execute.sh
+++ b/scripts/file_update/execute.sh
@@ -78,10 +78,15 @@ fi
 
 # Update manifest.txt file for each submission
 if [ "$UPDATE_MANIFEST_TXT" == true ] && [ "$BUCKET_LOCATION" == $STORE_BUCKET ]; then
-  echo "Updating manifest.txt file (in source and target submission)"
-  python manifest_txt_update.py --s3_key_object "$SOURCE_SORT_KEY"
-  python manifest_txt_update.py --s3_key_object "$TARGET_SORT_KEY"
-
+  if [ "$SOURCE_SORT_KEY" == "$TARGET_SORT_KEY" ];
+    then
+      echo "Updating manifest.txt file once ( source and target key is the same)"
+      python manifest_txt_update.py --s3_key_object "$SOURCE_SORT_KEY"
+    else
+      echo "Updating manifest.txt file (in source and target submission)"
+      python manifest_txt_update.py --s3_key_object "$SOURCE_SORT_KEY"
+      python manifest_txt_update.py --s3_key_object "$TARGET_SORT_KEY"
+  fi
 fi
 
 # Move '__results.json' location

--- a/scripts/reports/bucket_summary/main.py
+++ b/scripts/reports/bucket_summary/main.py
@@ -21,7 +21,7 @@ DYNAMODB_STAGING_TABLE = "agha-gdr-staging-bucket"
 DYNAMODB_STORE_TABLE = "agha-gdr-store-bucket"
 
 flagships = list(set(agha.FlagShip.list_flagship_enum()) - {agha.FlagShip.UNKNOWN.preferred_code(),
-                                                            agha.FlagShip.UNKNOWN.preferred_code()})
+                                                            agha.FlagShip.TEST.preferred_code()})
 
 
 class Report:

--- a/scripts/reports/bucket_summary/main.py
+++ b/scripts/reports/bucket_summary/main.py
@@ -20,8 +20,7 @@ STORE_BUCKET_NAME = 'agha-gdr-store-2.0'
 DYNAMODB_STAGING_TABLE = "agha-gdr-staging-bucket"
 DYNAMODB_STORE_TABLE = "agha-gdr-store-bucket"
 
-flagships = ['Leuko', 'GI', 'EE', 'BM', 'HIDDEN', 'chILDRANZ', 'AC', 'Mito', 'KidGen', 'ID',
-             'ICCon', 'Cardiac']
+flagships = list(set(agha.FlagShip.list_flagship_enum())-{agha.FlagShip.UNKNOWN.preferred_code(), agha.FlagShip.UNKNOWN.preferred_code()})
 
 
 class Report:


### PR DESCRIPTION
- When executing file-update script, only update manifest.txt one time if keys are the same. (Used to be 2 times for each source and destination key)
- Bucket summary includes `MM` flagships
- FileType count method is changed