### PR TITLE
Update duplication behaviour

### DIFF
--- a/lambdas/functions/manifest_processor/manifest_processor.py
+++ b/lambdas/functions/manifest_processor/manifest_processor.py
@@ -22,7 +22,7 @@ AUTORUN_VALIDATION_JOBS = os.environ.get("AUTORUN_VALIDATION_JOBS")
 
 # NOTE(SW): it seems reasonable to require some structuring of uploads in the format of
 # <FLAGSHIP>/<DATE_TS>/<FILES ...>. Outcomes on upload wrt directory structure:
-#   1. meets prescribed structure and we automatically launch validation jobs
+#   1. meets prescribed structure, and we automatically launch validation jobs
 #   2. differs from prescribed structure and data manager is notified to fix and then launch jobs
 #
 # Similarly, this logic could be applied to anything that might block or interfere with validation
@@ -403,7 +403,7 @@ def handler(event, context):
         ####################################################
         if skip_duplication_check:
             logger.info("Skipping duplication check")
-            continue
+            pass
         else:
             if number_of_duplicates > 0:
                 report_info = {
@@ -493,7 +493,7 @@ def handler(event, context):
             logger.info(f"'skip_update_dynamodb' payload is True. Skipping ...")
 
         ####################################################
-        # Trigerring other lambda
+        # Triggering other lambda
         ####################################################
         if AUTORUN_VALIDATION_JOBS == "yes" and not skip_auto_validation:
 

--- a/lambdas/functions/manifest_processor/manifest_processor.py
+++ b/lambdas/functions/manifest_processor/manifest_processor.py
@@ -213,7 +213,7 @@ def handler(event, context):
                 "submission_prefix": data.manifest_s3_key,
             }
             util.call_lambda(FOLDER_LOCK_LAMBDA_ARN, payload)
-            notification.log_and_store_message(f"Unlocking submission directory.")
+            notification.log_and_store_message(f"Submission directory unlocked.")
 
             notification.notify_and_exit()
             raise ValueError(e)


### PR DESCRIPTION
Duplication behaviour update:
- Will now raise an error and unlock bucket, rather than just a warning
- Allow skipping duplication check if needed via manual trigger. (manual lambda invoke)