### PR TITLE
Split Large deletion request into loops

### DIFF
--- a/lambdas/functions/cleanup_manager/cleanup_manager.py
+++ b/lambdas/functions/cleanup_manager/cleanup_manager.py
@@ -97,7 +97,7 @@ def handler(event, context):
             res = s3.delete_s3_object_from_key(
                 bucket_name=STAGING_BUCKET, key_list=deletion_key_list
             )
-            logger.debug(f"Deletion response {res}")
+            logger.debug(f"Deletion response: {json.dumps(res, indent=4)}")
             logger.info(f"Deletion job success!")
 
         except Exception as e:


### PR DESCRIPTION
Some submission (e.g. MM_VCGS) have large deletion request during cleanup.

Boto3 have a limit on the `delete_objects()` function to accept maximum of 1000 keys per request.

Updating this on this PR.