### PR TITLE
fix: Prevent Submit Batch Job Limit

### DIFF
--- a/lambdas/functions/data_transfer_manager/data_transfer_manager.py
+++ b/lambdas/functions/data_transfer_manager/data_transfer_manager.py
@@ -271,13 +271,13 @@ def handler(event, context):
         for i, job_data in enumerate(batch_job_data):
             submit_data_transfer_job(job_data)
 
-            # Sleep for 1 second every 10th job
+            # Sleep for 1 second every 8th job
             # This is to prevent AWS Batch SubmitJob throttling limit of 50 jobs per second
-            # Putting 10 here as it is shared across 3 reserved concurrency limit, and
+            # Putting (50/6=) 8 here as it is shared across 3 reserved concurrency limit, and
             # 2 lambda function (transfer-manager and validation-manager)
             # Without sleep, the average of submitting jobs is about 13 jobs per second
             # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
-            if (i + 1) % 10 == 0:
+            if (i + 1) % 8 == 0:
                 time.sleep(1)
 
         logger.info(

--- a/lambdas/functions/data_transfer_manager/data_transfer_manager.py
+++ b/lambdas/functions/data_transfer_manager/data_transfer_manager.py
@@ -271,9 +271,11 @@ def handler(event, context):
         for i, job_data in enumerate(batch_job_data):
             submit_data_transfer_job(job_data)
 
-            # Sleep for 1 second every 15th job
+            # Sleep for 1 second every 10th job
             # This is to prevent AWS Batch SubmitJob throttling limit of 50 jobs per second
-            # Putting 15 here as it is shared across 3 reserved concurency limit
+            # Putting 10 here as it is shared across 3 reserved concurrency limit, and
+            # 2 lambda function (transfer-manager and validation-manager)
+            # Without sleep, the average of submitting jobs is about 13 jobs per second
             # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
             if (i + 1) % 15 == 0:
                 time.sleep(1)

--- a/lambdas/functions/data_transfer_manager/data_transfer_manager.py
+++ b/lambdas/functions/data_transfer_manager/data_transfer_manager.py
@@ -255,10 +255,10 @@ def handler(event, context):
             f",Error: {e}",
         }
 
-    logger.info("Submit AWS Batch Job list:")
+    logger.info(f"Submit AWS Batch Job list ({len(batch_job_data)}):")
     logger.info(json.dumps(batch_job_data))
 
-    logger.info("Update Dynamodb list:")
+    logger.info(f"Update Dynamodb list ({len(dynamodb_job)}):")
     logger.info(
         json.dumps([item.__dict__ for item in dynamodb_job], cls=util.JsonSerialEncoder)
     )

--- a/lambdas/functions/data_transfer_manager/data_transfer_manager.py
+++ b/lambdas/functions/data_transfer_manager/data_transfer_manager.py
@@ -277,7 +277,7 @@ def handler(event, context):
             # 2 lambda function (transfer-manager and validation-manager)
             # Without sleep, the average of submitting jobs is about 13 jobs per second
             # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
-            if (i + 1) % 15 == 0:
+            if (i + 1) % 10 == 0:
                 time.sleep(1)
 
         logger.info(

--- a/lambdas/functions/validation_manager/validation_manager.py
+++ b/lambdas/functions/validation_manager/validation_manager.py
@@ -261,9 +261,11 @@ def handler(event, context):
         # Submit job to batch
         batch_res = batch.submit_batch_job(job_data)
 
-        # Sleep for 1 second every 15th job
+        # Sleep for 1 second every 10th job
         # This is to prevent AWS Batch SubmitJob throttling limit of 50 jobs per second
-        # Putting 15 here as it is shared across 3 reserved concurency limit
+        # Putting 10 here as it is shared across 3 reserved concurrency limit, and
+        # 2 lambda function (transfer-manager and validation-manager)
+        # Without sleep, the average of submitting jobs is about 13 jobs per second
         # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
         if (i + 1) % 15 == 0:
             time.sleep(1)

--- a/lambdas/functions/validation_manager/validation_manager.py
+++ b/lambdas/functions/validation_manager/validation_manager.py
@@ -261,13 +261,13 @@ def handler(event, context):
         # Submit job to batch
         batch_res = batch.submit_batch_job(job_data)
 
-        # Sleep for 1 second every 10th job
+        # Sleep for 1 second every 8th job
         # This is to prevent AWS Batch SubmitJob throttling limit of 50 jobs per second
-        # Putting 10 here as it is shared across 3 reserved concurrency limit, and
+        # Putting (50/6=) 8 here as it is shared across 3 reserved concurrency limit, and
         # 2 lambda function (transfer-manager and validation-manager)
         # Without sleep, the average of submitting jobs is about 13 jobs per second
         # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
-        if (i + 1) % 10 == 0:
+        if (i + 1) % 8 == 0:
             time.sleep(1)
 
     logger.info("Batch job has been submitted.")

--- a/lambdas/functions/validation_manager/validation_manager.py
+++ b/lambdas/functions/validation_manager/validation_manager.py
@@ -267,7 +267,7 @@ def handler(event, context):
         # 2 lambda function (transfer-manager and validation-manager)
         # Without sleep, the average of submitting jobs is about 13 jobs per second
         # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
-        if (i + 1) % 15 == 0:
+        if (i + 1) % 10 == 0:
             time.sleep(1)
 
     logger.info("Batch job has been submitted.")

--- a/lambdas/functions/validation_manager/validation_manager.py
+++ b/lambdas/functions/validation_manager/validation_manager.py
@@ -2,7 +2,7 @@
 import json
 import logging
 import os
-import sys
+import time
 import pandas as pd
 
 import util
@@ -254,13 +254,21 @@ def handler(event, context):
 
     # Submit Batch jobs
     logger.info(
-        f"Submitting batch job to queue. batch job data list: {json.dumps(batch_job_data, indent=4)}"
+        f"Submitting batch job to queue. batch job data list ({len(batch_job_data)}):"
     )
-    for job_data in batch_job_data:
+    logger.info(json.dumps(batch_job_data))
+    for i, job_data in enumerate(batch_job_data):
         # Submit job to batch
         batch_res = batch.submit_batch_job(job_data)
-        logger.debug(f"Submit batch job res: {batch_res}")
-    logger.info(f"Batch job has executed. Submit {len(batch_job_data)} number of job")
+
+        # Sleep for 1 second every 15th job
+        # This is to prevent AWS Batch SubmitJob throttling limit of 50 jobs per second
+        # Putting 15 here as it is shared across 3 reserved concurency limit
+        # https://docs.aws.amazon.com/batch/latest/userguide/service_limits.html
+        if (i + 1) % 15 == 0:
+            time.sleep(1)
+
+    logger.info("Batch job has been submitted.")
 
 
 ################################################################

--- a/lambdas/layers/util/util/submission_data.py
+++ b/lambdas/layers/util/util/submission_data.py
@@ -98,6 +98,9 @@ def validate_manifest(
     is_checksum_unique = data.manifest_data["checksum"].dropna().is_unique
 
     if not is_checksum_unique:
+        notification.log_and_store_message(
+            "Manifest contain duplicated checksums value", level="critical"
+        )
         raise ValueError(
             json.dumps(
                 "Manifest contain duplicated checksums",

--- a/stacks/agha_stacks/lambda_stack.py
+++ b/stacks/agha_stacks/lambda_stack.py
@@ -231,7 +231,8 @@ class LambdaStack(core.NestedStack):
             function_name=f"{namespace}-validation-manager",
             handler="validation_manager.handler",
             runtime=lambda_.Runtime.PYTHON_3_8,
-            timeout=core.Duration.seconds(300),
+            timeout=core.Duration.minutes(10),
+            reserved_concurrent_executions=3,  # To prevent AWS Batch Limit (See the lambda code on AWS BatchSubmitJob)
             retry_attempts=0,
             code=lambda_.Code.from_asset("lambdas/functions/validation_manager"),
             environment={
@@ -500,7 +501,8 @@ class LambdaStack(core.NestedStack):
             function_name=f"{namespace}-data-transfer-manager",
             handler="data_transfer_manager.handler",
             runtime=lambda_.Runtime.PYTHON_3_8,
-            timeout=core.Duration.seconds(300),
+            timeout=core.Duration.minutes(10),
+            reserved_concurrent_executions=3,  # To prevent AWS Batch Limit (See the lambda code on AWS BatchSubmitJob)
             retry_attempts=0,
             code=lambda_.Code.from_asset("lambdas/functions/data_transfer_manager"),
             environment={


### PR DESCRIPTION
A quick solution to prevent submitting 50 AWS Batch jobs per second. By putting one second sleep after 10th submit jobs and limit lambda 3 reserved concurrency this should prevent batch job limit.

Affected lambdas:
- Transfer manager (trigger to move files from `stg` - > `prod`)
- Validation manager (trigger the file validation test)

Eventually if both lambdas (with all their concurrency) run the same time and speed (should be a rare case), it may still possible to run to this issue. Cloud watch logs now print the jobs before updating dynamodb/batchjob submit so the array can be retrieved and rerun.

Related #28 
