### PR TITLE
Fix: fetch aws-cli from `public.ecr`

### DIFF
--- a/lambdas/functions/data_transfer_manager/tests/__init__.py
+++ b/lambdas/functions/data_transfer_manager/tests/__init__.py
@@ -20,7 +20,8 @@ os.environ["RESULTS_BUCKET"] = "agha-gdr-results-2.0"
 os.environ["STORE_BUCKET"] = "agha-gdr-store-2.0"
 os.environ[
     "S3_JOB_DEFINITION_ARN"
-] = "arn:aws:batch:ap-southeast-2:843407916570:job-definition/agha-gdr-s3-manipulation:11"
-os.environ[
-    "BATCH_QUEUE_NAME"
-] = '{"small": "agha-gdr-pipeline-job-queue-small", "medium": "agha-gdr-pipeline-job-queue-medium", "large": "agha-gdr-pipeline-job-queue-large", "xlarge": "agha-gdr-pipeline-job-queue-xlarge"}'
+] = "arn:aws:batch:ap-southeast-2:602836945884:job-definition/agha-gdr-s3-manipulation:15"
+os.environ["BATCH_QUEUE_NAME"] = (
+    '{"small": "agha-validation-pipeline-job-queue-small", "medium": "agha-validation-pipeline-job-queue-medium", '
+    '"large": "agha-validation-pipeline-job-queue-large", "xlarge": "agha-validation-pipeline-job-queue-xlarge"} '
+)

--- a/lambdas/layers/util/util/agha.py
+++ b/lambdas/layers/util/util/agha.py
@@ -2,7 +2,7 @@ import re
 from enum import Enum
 from typing import List
 
-AGHA_ID_PATTERN = re.compile("A\d{7,8}(?:_mat|_pat|_R1|_R2|_R3)?|unknown")
+AGHA_ID_PATTERN = re.compile(r"A\d{7,8}(?:_mat|_pat|_R1|_R2|_R3)?|unknown")
 MD5_PATTERN = re.compile("[0-9a-f]{32}")
 
 

--- a/scripts/handle_delete_files/main.py
+++ b/scripts/handle_delete_files/main.py
@@ -1,4 +1,3 @@
-from util import s3
 import json
 import os
 import sys
@@ -6,6 +5,8 @@ import sys
 DIR_PATH = os.path.dirname(os.path.realpath(__file__))
 SOURCE_PATH = os.path.join(DIR_PATH, "..", "..", "lambdas", "layers", "util")
 sys.path.append(SOURCE_PATH)
+
+from util import s3
 
 # Environment variable that may be used in Utils
 os.environ["DYNAMODB_ARCHIVE_RESULT_TABLE_NAME"] = "agha-gdr-result-bucket-archive"

--- a/stacks/agha_stacks/batch_stack.py
+++ b/stacks/agha_stacks/batch_stack.py
@@ -220,7 +220,9 @@ class BatchStack(core.NestedStack):
             "S3BatchJobDefinition",
             job_definition_name=batch_environment["s3_job_definition_name"],
             container=batch.JobDefinitionContainer(
-                image=ecs.ContainerImage.from_registry("amazon/aws-cli:latest"),
+                image=ecs.ContainerImage.from_registry(
+                    "public.ecr.aws/aws-cli/aws-cli:latest"
+                ),
                 command=["true"],
                 memory_limit_mib=2000,
                 vcpus=1,


### PR DESCRIPTION
- Fetch aws-cli image from `public.ecr` to avoid `ERROR: toomanyrequests: Too Many Requests`
- Minor updates