### PR TITLE
Update gdr-s3-data-sharing.md

### DIFF
--- a/docs/gdr-s3-data-sharing.md
+++ b/docs/gdr-s3-data-sharing.md
@@ -101,6 +101,7 @@ We need to specify which actions are allowed under the bucket permissions.
           "Action": [
               "s3:GetObject",
               "s3:PutObject",
+              "s3:DeleteObject",
               "s3:PutObjectAcl",
               "s3:ListBucket",
               "s3:GetBucketLocation"


### PR DESCRIPTION
Add `s3:DeleteObject` permissions for better control of the destination bucket.